### PR TITLE
Update_set-env.ts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,9 +4,9 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "start:prod": "ng serve --configuration production",
+    "start:prod": "node set-env.ts && ng serve --configuration production --open",
     "build": "ng build",
-    "build:prod": "ng build --configuration production",
+    "build:prod": "node set-env.ts && ng build --configuration production",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "serve:ssr:artcreation-dv": "node dist/artcreation-dv/server/server.mjs",

--- a/frontend/set-env.ts
+++ b/frontend/set-env.ts
@@ -1,0 +1,12 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const fs = require('fs');
+const targetPath = "./src/environments/environment.prod.ts";
+const envConfigFile = `import { Environment } from "./environment.model";
+
+export const environment: Environment = {
+    production: true,
+    API_BASE_URL: '${process.env['API_URL']}'
+};
+`;
+fs.writeFileSync(targetPath, envConfigFile);
+console.log(`Output generated at ${targetPath}`);

--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -3,4 +3,4 @@ import { Environment } from "./environment.model";
 export const environment: Environment = {
     production: true,
     API_BASE_URL: ''
-}
+};

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,12 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
+import { environment } from './environments/environment';
+import { enableProdMode } from '@angular/core';
+
+if(environment.production) {
+  enableProdMode();
+}
 
 bootstrapApplication(AppComponent, appConfig)
   .catch((err) => console.error(err));


### PR DESCRIPTION
Add set-env.ts to overwrite environment variables on prod build. Adapt custom npm scripts to include run of set-env.ts on deployment.